### PR TITLE
rename package to test-helpers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::799847381734:role/cptest-test-gbl-sandbox-tester
-          role-session-name: githubaction-test-repo-terratest-helpers
+          role-session-name: githubaction-test-repo-test-helpers
           aws-region: us-east-2
 
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-
-
 <!-- markdownlint-disable -->
-# terratest-helpers <a href="https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terratest-helpers&utm_content="><img align="right" src="https://cloudposse.com/logo-300x69.svg" width="150" /></a>
-<a href="https://github.com/cloudposse/terratest-helpers/releases/latest"><img src="https://img.shields.io/github/release/cloudposse/terratest-helpers.svg" alt="Latest Release"/></a><a href="https://slack.cloudposse.com"><img src="https://slack.cloudposse.com/badge.svg" alt="Slack Community"/></a>
+
+# test-helpers <a href="https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/test-helpers&utm_content="><img align="right" src="https://cloudposse.com/logo-300x69.svg" width="150" /></a>
+
+<a href="https://github.com/cloudposse/test-helpers/releases/latest"><img src="https://img.shields.io/github/release/cloudposse/test-helpers.svg" alt="Latest Release"/></a><a href="https://slack.cloudposse.com"><img src="https://slack.cloudposse.com/badge.svg" alt="Slack Community"/></a>
+
 <!-- markdownlint-restore -->
 
 <!--
@@ -26,39 +27,34 @@
 
 -->
 
-`terratest-helpers` is a library that adds some missing functionality to [terratest](https://terratest.gruntwork.io).
-
-
-
+`test-helpers` is a library that adds some missing functionality to [terratest](https://terratest.gruntwork.io).
 
 ## Introduction
 
+`test-helpers` is a library that adds some missing functionality to [terratest](https://terratest.gruntwork.io).
 
-`terratest-helpers` is a library that adds some missing functionality to [terratest](https://terratest.gruntwork.io).
+`test-helpers` includes functionality for:
 
-`terratest-helpers` includes functionality for:
-
-   - Destroying all resources in an AWS account after a test run using [aws-nuke](https://github.com/rebuy-de/aws-nuke)
-   - Running tests with [atmos](https://github.com/cloudposse/atmos) stack configs
-
+- Destroying all resources in an AWS account after a test run using [aws-nuke](https://github.com/rebuy-de/aws-nuke)
+- Running tests with [atmos](https://github.com/cloudposse/atmos) stack configs
 
 ## Install
 
 Install the latest version in your go tests
 
 ```console
-go install github.com/cloudposse/terratest-helpers
+go install github.com/cloudposse/test-helpers
 ```
 
 Get a specific version
 
 ```console
-go install github.com/cloudposse/terratest-helpers@v0.0.1
+go install github.com/cloudposse/test-helpers@v0.0.1
 ```
 
 ## Usage
 
-You can use `terratest-helpers` as a library in your own terratest code.
+You can use `test-helpers` as a library in your own terratest code.
 
 ### atmos
 
@@ -114,63 +110,50 @@ func TestAwsNuke(t *testing.T) {
 }
 ```
 
-
 ## Examples
 
-The [example](examples/) folder contains a full set examples that demonstrate the use of `terratest-helpers`:
+The [example](examples/) folder contains a full set examples that demonstrate the use of `test-helpers`:
 
-  - [example](examples/awsnuke-example) folder contains a terraform module that can be used to test the `awsnuke` functionality.
+- [example](examples/awsnuke-example) folder contains a terraform module that can be used to test the `awsnuke` functionality.
   The test for this module is in [pkg/awsnuke/awsnuke_test.go](pkg/awsnuke/awsnuke_test.go).
-
-
-
-
-
-
-
-
-
-
-
-
 
 ## ✨ Contributing
 
 This project is under active development, and we encourage contributions from our community.
 
-
-
 Many thanks to our outstanding contributors:
 
-<a href="https://github.com/cloudposse/terratest-helpers/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=cloudposse/terratest-helpers&max=24" />
+<a href="https://github.com/cloudposse/test-helpers/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=cloudposse/test-helpers&max=24" />
 </a>
 
-For 🐛 bug reports & feature requests, please use the [issue tracker](https://github.com/cloudposse/terratest-helpers/issues).
+For 🐛 bug reports & feature requests, please use the [issue tracker](https://github.com/cloudposse/test-helpers/issues).
 
 In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
- 1. Review our [Code of Conduct](https://github.com/cloudposse/terratest-helpers/?tab=coc-ov-file#code-of-conduct) and [Contributor Guidelines](https://github.com/cloudposse/.github/blob/main/CONTRIBUTING.md).
- 2. **Fork** the repo on GitHub
- 3. **Clone** the project to your own machine
- 4. **Commit** changes to your own branch
- 5. **Push** your work back up to your fork
- 6. Submit a **Pull Request** so that we can review your changes
+
+1.  Review our [Code of Conduct](https://github.com/cloudposse/test-helpers/?tab=coc-ov-file#code-of-conduct) and [Contributor Guidelines](https://github.com/cloudposse/.github/blob/main/CONTRIBUTING.md).
+2.  **Fork** the repo on GitHub
+3.  **Clone** the project to your own machine
+4.  **Commit** changes to your own branch
+5.  **Push** your work back up to your fork
+6.  Submit a **Pull Request** so that we can review your changes
 
 **NOTE:** Be sure to merge the latest changes from "upstream" before making a pull request!
 
 ### 🌎 Slack Community
 
-Join our [Open Source Community](https://cpco.io/slack?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terratest-helpers&utm_content=slack) on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
+Join our [Open Source Community](https://cpco.io/slack?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/test-helpers&utm_content=slack) on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally _sweet_ infrastructure.
 
 ### 📰 Newsletter
 
-Sign up for [our newsletter](https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terratest-helpers&utm_content=newsletter) and join 3,000+ DevOps engineers, CTOs, and founders who get insider access to the latest DevOps trends, so you can always stay in the know.
+Sign up for [our newsletter](https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/test-helpers&utm_content=newsletter) and join 3,000+ DevOps engineers, CTOs, and founders who get insider access to the latest DevOps trends, so you can always stay in the know.
 Dropped straight into your Inbox every week — and usually a 5-minute read.
 
-### 📆 Office Hours <a href="https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terratest-helpers&utm_content=office_hours"><img src="https://img.cloudposse.com/fit-in/200x200/https://cloudposse.com/wp-content/uploads/2019/08/Powered-by-Zoom.png" align="right" /></a>
+### 📆 Office Hours <a href="https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/test-helpers&utm_content=office_hours"><img src="https://img.cloudposse.com/fit-in/200x200/https://cloudposse.com/wp-content/uploads/2019/08/Powered-by-Zoom.png" align="right" /></a>
 
-[Join us every Wednesday via Zoom](https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terratest-helpers&utm_content=office_hours) for your weekly dose of insider DevOps trends, AWS news and Terraform insights, all sourced from our SweetOps community, plus a _live Q&A_ that you can’t find anywhere else.
+[Join us every Wednesday via Zoom](https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/test-helpers&utm_content=office_hours) for your weekly dose of insider DevOps trends, AWS news and Terraform insights, all sourced from our SweetOps community, plus a _live Q&A_ that you can’t find anywhere else.
 It's **FREE** for everyone!
+
 ## License
 
 <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge" alt="License"></a>
@@ -200,17 +183,17 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 ```
+
 </details>
 
 ## Trademarks
 
 All other trademarks referenced herein are the property of their respective owners.
 
-
 ---
+
 Copyright © 2017-2024 [Cloud Posse, LLC](https://cpco.io/copyright)
 
+<a href="https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/test-helpers&utm_content=readme_footer_link"><img alt="README footer" src="https://cloudposse.com/readme/footer/img"/></a>
 
-<a href="https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terratest-helpers&utm_content=readme_footer_link"><img alt="README footer" src="https://cloudposse.com/readme/footer/img"/></a>
-
-<img alt="Beacon" width="0" src="https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terratest-helpers?pixel&cs=github&cm=readme&an=terratest-helpers"/>
+<img alt="Beacon" width="0" src="https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/test-helpers?pixel&cs=github&cm=readme&an=test-helpers"/>

--- a/README.yaml
+++ b/README.yaml
@@ -1,10 +1,10 @@
-name: terratest-helpers
+name: test-helpers
 license: APACHE2
-github_repo: cloudposse/terratest-helpers
+github_repo: cloudposse/test-helpers
 badges:
   - name: Latest Release
-    image: https://img.shields.io/github/release/cloudposse/terratest-helpers.svg
-    url: https://github.com/cloudposse/terratest-helpers/releases/latest
+    image: https://img.shields.io/github/release/cloudposse/test-helpers.svg
+    url: https://github.com/cloudposse/test-helpers/releases/latest
   - name: Slack Community
     image: https://slack.cloudposse.com/badge.svg
     url: https://slack.cloudposse.com
@@ -19,13 +19,13 @@ categories:
   - terratest
 
 description: |-
-  `terratest-helpers` is a library that adds some missing functionality to [terratest](https://terratest.gruntwork.io).
+  `test-helpers` is a library that adds some missing functionality to [terratest](https://terratest.gruntwork.io).
 
 introduction: |-
 
-  `terratest-helpers` is a library that adds some missing functionality to [terratest](https://terratest.gruntwork.io).
+  `test-helpers` is a library that adds some missing functionality to [terratest](https://terratest.gruntwork.io).
 
-  `terratest-helpers` includes functionality for:
+  `test-helpers` includes functionality for:
 
      - Destroying all resources in an AWS account after a test run using [aws-nuke](https://github.com/rebuy-de/aws-nuke)
      - Running tests with [atmos](https://github.com/cloudposse/atmos) stack configs
@@ -36,18 +36,18 @@ introduction: |-
   Install the latest version in your go tests
 
   ```console
-  go install github.com/cloudposse/terratest-helpers
+  go install github.com/cloudposse/test-helpers
   ```
 
   Get a specific version
 
   ```console
-  go install github.com/cloudposse/terratest-helpers@v0.0.1
+  go install github.com/cloudposse/test-helpers@v0.0.1
   ```
 
   ## Usage
 
-  You can use `terratest-helpers` as a library in your own terratest code.
+  You can use `test-helpers` as a library in your own terratest code.
 
   ### atmos
 
@@ -106,7 +106,7 @@ introduction: |-
 
   ## Examples
 
-  The [example](examples/) folder contains a full set examples that demonstrate the use of `terratest-helpers`:
+  The [example](examples/) folder contains a full set examples that demonstrate the use of `test-helpers`:
 
     - [example](examples/awsnuke-example) folder contains a terraform module that can be used to test the `awsnuke` functionality.
     The test for this module is in [pkg/awsnuke/awsnuke_test.go](pkg/awsnuke/awsnuke_test.go).

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/cloudposse/terratest-helpers
+module github.com/cloudposse/test-helpers
 
-go 1.21
+go 1.23
 
 require (
 	github.com/gruntwork-io/terratest v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -443,6 +443,8 @@ github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEM
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
 github.com/cloudposse/atmos v1.54.0 h1:cg5uAOIKf8gImEJ9q+viKCrJTdTAYotOcYSDct60YKw=
 github.com/cloudposse/atmos v1.54.0/go.mod h1:U4JpQjh8MUZii0jTLDHqNzXxAslNs9mRSh81LyIxkDY=
+github.com/cloudposse/test-helpers v0.10.0 h1:xCOJmUtm0U7/zCLsvTaQ+p3qH00+rrMB28ol+weUYkI=
+github.com/cloudposse/test-helpers v0.10.0/go.mod h1:+Z7HX9IXLvwzFGHh7CXFwWWoHda58FAdAAqjm7llWBw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/pkg/atmos/aws_component_test_helper.go
+++ b/pkg/atmos/aws_component_test_helper.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cloudposse/terratest-helpers/pkg/awsnuke"
+	"github.com/cloudposse/test-helpers/pkg/awsnuke"
 	"github.com/gruntwork-io/terratest/modules/files"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
## what
* Rename from `terratest-helpers` to `test-helpers`

## why
* Make the repo name better reflect the broader scope of the package.