### PR TITLE
allow skipping test runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,9 @@ func TestMain(m *testing.M) {
   defer suite.TearDown(t)
   suite.Setup(t)
 
-  m.Run()
+  if !suite.SkipTests {
+    m.Run()
+  }
 }
 
 func TestBastion(t *testing.T) {

--- a/README.yaml
+++ b/README.yaml
@@ -154,7 +154,9 @@ introduction: |-
     defer suite.TearDown(t)
     suite.Setup(t)
 
-    m.Run()
+    if !suite.SkipTests {
+      m.Run()
+    }
   }
 
   func TestBastion(t *testing.T) {

--- a/pkg/atmos/aws-component-helper/cli.go
+++ b/pkg/atmos/aws-component-helper/cli.go
@@ -14,6 +14,7 @@ func parseCLIArgs(ts *TestSuite) *TestSuite {
 	skipTeardownTestSuite := flag.Bool("skip-teardown", ts.SkipTeardownTestSuite, "skip test suite teardown")
 	skipVendorDependencies := flag.Bool("skip-vendor", ts.SkipVendorDependencies, "skip vendor dependencies")
 	skipVerifyEnabledFlag := flag.Bool("skip-verify-enabled-flag", ts.SkipVerifyEnabledFlag, "skip verify enabled flag")
+	skipTests := flag.Bool("skip-tests", ts.SkipTests, "skip tests")
 
 	flag.Parse()
 
@@ -28,6 +29,7 @@ func parseCLIArgs(ts *TestSuite) *TestSuite {
 	ts.SkipTeardownTestSuite = *skipTeardownTestSuite
 	ts.SkipVendorDependencies = *skipVendorDependencies
 	ts.SkipVerifyEnabledFlag = *skipVerifyEnabledFlag
+	ts.SkipTests = *skipTests
 	return ts
 }
 

--- a/pkg/atmos/aws-component-helper/test_suite.go
+++ b/pkg/atmos/aws-component-helper/test_suite.go
@@ -24,6 +24,7 @@ type TestSuite struct {
 	SkipDestroyComponentUnderTest bool
 	SkipDestroyDependencies       bool
 	SkipTeardownTestSuite         bool
+	SkipTests                     bool
 	SkipVendorDependencies        bool
 	SkipVerifyEnabledFlag         bool
 	SkipNukeTestAccount           bool

--- a/test/aws-component-helper/test/basic_test.go
+++ b/test/aws-component-helper/test/basic_test.go
@@ -40,7 +40,9 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
-	m.Run()
+	if !suite.SkipTests {
+		m.Run()
+	}
 }
 
 func TestBasic(t *testing.T) {


### PR DESCRIPTION
## what
* allow skipping test runs with the `-skip-tests` flag

## why
* to give the developer more flexibility when iterating locally