### PR TITLE
set ATMOS_TEST_HELPER_STATE_DIR env var for atmos commands

### DIFF
--- a/pkg/atmos/component-helper/atmos_options.go
+++ b/pkg/atmos/component-helper/atmos_options.go
@@ -28,8 +28,11 @@ func getAtmosOptions(t *testing.T, config *c.Config, componentName string, stack
 		BackendConfig: map[string]interface{}{
 			"workspace_key_prefix": strings.Join([]string{config.RandomIdentifier, stackName}, "-"),
 		},
-		Vars:    mergedVars,
-		EnvVars: map[string]string{"ATMOS_BASE_PATH": config.TempDir},
+		Vars: mergedVars,
+		EnvVars: map[string]string{
+			"ATMOS_BASE_PATH":            config.TempDir,
+			"COMPONENT_HELPER_STATE_DIR": config.StateDir,
+		},
 	}
 	return atmosOptions
 }


### PR DESCRIPTION
## what
* Added `ATMOS_TEST_HELPER_STATE_DIR` environment variable to the Atmos options configuration, pointing to the temporary directory

## why
* Allow the state directory to be set to a well known path via `--state-dir` and also work with the [terraform-provider-utils](https://github.com/cloudposse/terraform-provider-utils) provider.
