### PR TITLE
add -only-deploy-dependencies flag

### DIFF
--- a/pkg/atmos/component-helper/README.md
+++ b/pkg/atmos/component-helper/README.md
@@ -198,6 +198,8 @@ Finally, The Helper will clean up the temporary directory and any other resource
 | -------------------------- | ----------------------------------------------------- | ----------------- |
 | -config                    | The path to the config file                           | test_suite.yaml   |
 | -fixtures-dir              | The path to the fixtures directory                    | fixtures          |
+| -only-deploy-dependencies  | Only run the deploy dependencies phase of tests       | false             |
+| -skip-deploy-component     | Skips running the deploy component phase of tests     | false             |
 | -skip-deploy-dependencies  | Skips running the deploy dependencies phase of tests  | false             |
 | -skip-destroy-component    | Skips running the destroy component phase of tests    | false             |
 | -skip-destroy-dependencies | Skips running the destroy dependencies phase of tests | false             |

--- a/pkg/atmos/component-helper/bools.go
+++ b/pkg/atmos/component-helper/bools.go
@@ -3,7 +3,8 @@ package component_helper
 import "github.com/cloudposse/test-helpers/pkg/atmos/component-helper/config"
 
 func anyPhasesSkipped(config *config.Config) bool {
-	return config.SkipDeployComponent ||
+	return config.OnlyDeployDependencies ||
+		config.SkipDeployComponent ||
 		config.SkipDeployDependencies ||
 		config.SkipDestroyComponent ||
 		config.SkipDestroyDependencies ||
@@ -11,3 +12,5 @@ func anyPhasesSkipped(config *config.Config) bool {
 		config.SkipTeardownTestSuite ||
 		config.SkipVendorDependencies
 }
+
+

--- a/pkg/atmos/component-helper/suite.go
+++ b/pkg/atmos/component-helper/suite.go
@@ -78,11 +78,22 @@ func (s *TestSuite) DeployAtmosComponent(t *testing.T, componentName string, sta
 }
 
 func (s *TestSuite) DestroyAtmosComponent(t *testing.T, componentName string, stackName string, additionalVars *map[string]interface{}) {
+	phaseName := fmt.Sprintf("destroy/atmos component/%s/%s", stackName, componentName)
+
+	if s.Config.SkipDestroyComponent {
+		s.logPhaseStatus(phaseName, "skipped")
+		return
+	}
+
+	s.logPhaseStatus(phaseName, "started")
+
 	mergedVars := s.getMergedVars(t, additionalVars)
 	atmosOptions := getAtmosOptions(t, s.Config, componentName, stackName, &mergedVars)
 
 	_, err := atmos.DestroyE(t, atmosOptions)
 	require.NoError(t, err)
+
+	s.logPhaseStatus(phaseName, "completed")
 }
 
 // Setup runs the setup phase of the test suite.


### PR DESCRIPTION
## what
* Added new flags `-only-deploy-dependencies` and `-skip-deploy-component` to control test execution phases
* Enhanced logging for component destruction phase with status updates
* Added phase status tracking for destroy operations

## why
* Provides more granular control over which test phases are executed
* Enables users to run only dependency deployments when needed
* Improves visibility into test execution progress with better logging
* Makes test debugging easier by allowing specific phase isolation

## references
* Related to test suite configuration improvements
* Enhances test execution flexibility described in component-helper README.md